### PR TITLE
Update test data download command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Test geoips_clavrx installation
     # Ensure GeoIPS Python environment is enabled.
 
     # Install the clavrx test data repo
-    git clone https://github.com/NRLMMD-GEOIPS/test_data_clavrx $GEOIPS_TESTDATA_DIR/test_data_clavrx
+    $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_clavrx
 
     # Run all tests
     $GEOIPS_PACKAGES_DIR/geoips_clavrx/tests/test_all.sh


### PR DESCRIPTION
Test data no longer hosted on github, update test data clone to pull from URL.

```
> $GEOIPS_PACKAGES_DIR/geoips/setup/check_system_requirements.sh test_data test_data_clavrx

Install log: $HOME/geoips/outdirs/logs/20230822.223857_install.log
Installing tests data repo test_data_clavrx .... 
  $HOME/geoips/test_data/test_data_clavrx/ from https://io.cira.colostate.edu/s/ACLKdS2Cpgd2qkc/download/test_data_clavrx.tgz

SUCCESS: Pulled and decompressed test_data_clavrx from https://io.cira.colostate.edu/s/ACLKdS2Cpgd2qkc/download/test_data_clavrx.tgz
```