### PR TITLE
v1.11.3 geoips_clavrx - VERSION RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,3 @@ Test geoips_clavrx installation
     # Run all tests
     $GEOIPS_PACKAGES_DIR/geoips_clavrx/tests/test_all.sh
 ```
-

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,6 +22,7 @@ Version 1.11
 .. toctree::
    :maxdepth: 1
 
+   v1_11_3
    v1_11_3a0
    v1_11_0
 

--- a/docs/source/releases/v1_11_3.rst
+++ b/docs/source/releases/v1_11_3.rst
@@ -10,19 +10,19 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Please see
-``$GEOIPS_PACKAGES_DIR/geoips/CHANGELOG_TEMPLATE.rst``
-for instructions on updating CHANGELOG appropriately
-with each PR.
+Version 1.11.3 (2023-09-22)
+***************************
 
-The release note that is currently, actively being updated in
-all geoips plugin repositories can be found in the file
-``$GEOIPS_PACKAGES_DIR/geoips/update_this_release_note``.
+Release Updates
+===============
 
-You can either:
+Add 1.11.3 release note
+---------------------------
 
-* update the appropriate release note in this repo directly.
-* or update this ``CHANGELOG.rst`` file with your release
-  notes, for simplicity (your notes will be moved to the
-  appropriate release note in ``docs/source/releases``
-  during the PR process)
+*From issue GEOIPS#363: 2023-09-22, version update*
+
+::
+
+    modified: CHANGELOG.rst
+    new file: docs/source/releases/v1_11_3.rst
+    modified: docs/source/releases/index.rst


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#346
required to close NRLMMD-GEOIPS/geoips#341

# Reviewer Instructions
* Please confirm merge is into 'main' branch from 'v1.11.3-release'
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates.

# Summary
Changes for version 1.11.3 update on repo geoips_clavrx.


See NRLMMD-GEOIPS/geoips#346 for additional repositories included in this update.
See NRLMMD-GEOIPS/geoips#341 for dev updates included in this update.

# Testing Instructions
<!-- Remove this section if this is a repo without tests-->
Install GEOIPS and clone v1.11.3-release branch for:
* geoips_clavrx
<!-- include additional repositories that must also be updated for tests to pass -->

Tests should return 0:
# The 'full_test.sh' will test ALL repos and test data available on github.com
$GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_test.sh
# Potentially only a subset of the 'test_all.sh' tests in each repo will work:
$GEOIPS_PACKAGES_DIR/geoips_clavrx/tests/test_all.sh

# Output 
<!-- Remove this section if this is a repo without outputs -->
<!-- Copy/paste appropriate output here if you installed and ran updates on open source -->

# Post Merge Steps
Once this PR has been merged, v1.11.3 will be tagged/released on the geoips_clavrx main branch.