### PR TITLE
fixed optional dependencies for geoips_clavrx repo

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,7 +22,7 @@ Version 1.12
 .. toctree::
    :maxdepth: 1
 
-   v1_12_0a0
+   v1_12_2a0
 
 Version 1.11
 ------------

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -16,6 +16,14 @@
 Release Notes
 *************
 
+Version 1.12
+------------
+
+.. toctree::
+   :maxdepth: 1
+
+   v1_12_0a0
+
 Version 1.11
 ------------
 

--- a/docs/source/releases/v1_12_0a0.rst
+++ b/docs/source/releases/v1_12_0a0.rst
@@ -1,0 +1,33 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.12.0a0 (2024-02-12)
+*****************************
+
+* Refactor: Clean up optional dependencies throughout the codebase.
+
+Refactoring Updates
+-------------------
+
+Clean up optional dependencies throughout the code base
+-------------------------------------------------------
+
+*From GEOIPS#338: 2023-07-19, Clean up optional dependencies*
+
+Some GeoIPS readers include optional dependency statements that are required to read
+certain file formats. While keeping these imports as optional is ok, we should clean up
+the manner in which this is implemented. To do so, we've created a separate
+geoips.testing.context_manager.py script which can handle optional imports scattered
+throughout the GeoIPS codebase. This is essentially replacing our old manner of optional
+dependencies with a new method that keeps things clean.
+
+- modified: geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py

--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -10,7 +10,7 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Version 1.12.0a0 (2024-02-12)
+Version 1.12.2a0 (2024-02-12)
 *****************************
 
 * Refactor: Clean up optional dependencies throughout the codebase.

--- a/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
+++ b/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
@@ -22,11 +22,11 @@ import numpy as np
 import xarray as xr
 from os.path import join
 
-from geoips.testing.context_manager import import_optional_dependences
+from geoips.utils.context_managers import import_optional_dependencies
 
 LOG = logging.getLogger(__name__)
 
-with import_optional_dependences(__file__):
+with import_optional_dependencies(__file__):
     """Attempt to import a package and print to LOG.info if the import fails."""
     from pyhdf.SD import SD, SDC
     from pyhdf.error import HDF4Error

--- a/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
+++ b/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
@@ -22,20 +22,14 @@ import numpy as np
 import xarray as xr
 from os.path import join
 
+from geoips.testing.context_manager import import_optional_dependences
+
 LOG = logging.getLogger(__name__)
 
-try:
+with import_optional_dependences(__file__):
+    """Attempt to import a package and print to LOG.info if the import fails."""
     from pyhdf.SD import SD, SDC
-except ImportError:
-    print(
-        "Failed import pyhdf.SD/SDC in clavrx_hdf4.py " + "If you need it, install it."
-    )
-try:
     from pyhdf.error import HDF4Error
-except ImportError:
-    print(
-        "Failed import pyhdf error in clavrx_hdf4.py " + "If you need it, install it."
-    )
 
 interface = "readers"
 family = "standard"


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] Required ***updates to other repos*** complete

# Related Issues
fixes NRLMMD-GEOIPS/geoips#338
This PR branches off of another GeoIPS [PR](https://github.com/NRLMMD-GEOIPS/geoips/pull/438), which changes the implementation of optional dependencies scattered throughout the code. Don't merge this branch until the GeoIPS PR is merged.

# Testing Instructions
Run geoips/tests/integration_tests/full_test.sh to ensure this PR works. Works on my end.

# Summary
*From GEOIPS#338: 2023-07-19, Clean up optional dependencies*

Some GeoIPS readers include optional dependency statements that are required to read
certain file formats. While keeping these imports as optional is ok, we should clean up
the manner in which this is implemented. To do so, we've created a separate
geoips.testing.context_manager.py script which can handle optional imports scattered
throughout the GeoIPS codebase. This is essentially replacing our old manner of optional
dependencies with a new method that keeps things clean.

- modified: geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
