### PR TITLE
implemented bug fix for import_optional_dependencies

### DIFF
--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -14,6 +14,7 @@ Version 1.12.2a0 (2024-02-12)
 *****************************
 
 * Refactor: Clean up optional dependencies throughout the codebase.
+* Bug Fix: Replace __file__ arg with loglevel="info"
 
 Refactoring Updates
 -------------------
@@ -29,5 +30,21 @@ the manner in which this is implemented. To do so, we've created a separate
 geoips.testing.context_manager.py script which can handle optional imports scattered
 throughout the GeoIPS codebase. This is essentially replacing our old manner of optional
 dependencies with a new method that keeps things clean.
+
+- modified: geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
+
+Bug Fixes
+---------
+
+Replace __file__ arg with loglevel="info"
+-----------------------------------------
+
+*Stems From GEOIPS#338: 2023-07-19, Clean up optional dependencies*
+
+The GeoIPS Clavrx Clean up optional dependencies PR accidentally added a legacy call to
+import_optional_dependencies (__file__), which was replaced with (loglevel=<log_name>).
+These optional dependencies could possibly be used in some tests, and we need to update
+the calls to ``import_optional_dependencies`` to use the ``loglevel`` argument rather
+than the ``__file__`` arg. This is a small and easy fix and should be merged quickly.
 
 - modified: geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py

--- a/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
+++ b/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
@@ -26,7 +26,7 @@ from geoips.utils.context_managers import import_optional_dependencies
 
 LOG = logging.getLogger(__name__)
 
-with import_optional_dependencies(__file__):
+with import_optional_dependencies(loglevel="info"):
     """Attempt to import a package and print to LOG.info if the import fails."""
     from pyhdf.SD import SD, SDC
     from pyhdf.error import HDF4Error


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
No issue has been created as this is a very small fix.

# Summary
The GeoIPS Clavrx Clean up optional dependencies PR accidentally added a legacy call to
import_optional_dependencies (__file__), which was replaced with (loglevel=<log_name>).
These optional dependencies could possibly be used in some tests, and we need to update
the calls to ``import_optional_dependencies`` to use the ``loglevel`` argument rather
than the ``__file__`` arg. This is a small and easy fix and should be merged quickly.

``modified: geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py``

