### PR TITLE
v1.12.2 geoips_clavrx - VERSION RELEASE - optional deps

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,7 +22,9 @@ Version 1.12
 .. toctree::
    :maxdepth: 1
 
+   v1_12_2
    v1_12_2a0
+   v1_12_1
 
 Version 1.11
 ------------

--- a/docs/source/releases/v1_12_1.rst
+++ b/docs/source/releases/v1_12_1.rst
@@ -1,0 +1,47 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.12.1 (2024-01-16)
+***************************
+
+* Testing Updates
+  
+  * Update reader unit tests to support multiple tests, and comparing mean
+* Add release note for v1.12.1
+
+Testing Updates
+===============
+  
+Update reader unit tests to support multiple tests, and comparing mean
+----------------------------------------------------------------------
+
+Return a list of parameters from clavrx_hdf reader unit test.
+
+::
+
+  modified:   geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
+
+Release Process
+===============
+
+Add release note for v1.12.1
+----------------------------
+
+*From GEOIPS#422: 2023-12-13, 1.12.0 release process updates*
+
+All updates until the next release (v1.12.1) will be included in
+this release note.
+
+::
+
+  modified: docs/source/releases/v1.12.1.rst
+  modified: docs/source/releases/index.rst

--- a/docs/source/releases/v1_12_2.rst
+++ b/docs/source/releases/v1_12_2.rst
@@ -10,15 +10,19 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Please see
-https://github.com/NRLMMD-GEOIPS/geoips/blob/main/CHANGELOG_TEMPLATE.rst
-for instructions on updating release notes appropriately
-with each PR.
+Version 1.12.2 (2024-04-24)
+**************************************
 
-The release note that is currently, actively being updated in
-all geoips plugin repositories is referenced in the file:
+Release Updates
+===============
 
-* https://github.com/NRLMMD-GEOIPS/geoips/blob/main/update_this_release_note
+Add 1.12.2 release note
+---------------------------
 
-* Please add all release notes for the current PR in the file referenced
-  within ``update_this_release note``.
+*From issue GEOIPS#493: 2024-04-24, version update*
+
+::
+
+    modified: CHANGELOG.rst
+    new file: docs/source/releases/v1_12_2.rst
+    modified: docs/source/releases/index.rst

--- a/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
+++ b/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
@@ -187,4 +187,4 @@ def get_test_files(test_data_dir):
 
 def get_test_parameters():
     """Get test data key and a variable to test."""
-    return {"data_key": "DATA", "data_var": "cld_height_acha"}
+    return [{"data_key": "DATA", "data_var": "cld_height_acha"}]


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#529
required to close NRLMMD-GEOIPS/geoips#506

# Reviewer Instructions
* Please confirm this PR is set up to merge from v1.12.2-release branch into main branch
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates (you may perform tests yourself, or review output included from another reviewer/assignee)

# Summary
Changes for version 1.12.2, uploaded with
1.12.2 update on repo geoips_clavrx.
See release note updates in 'Files changed' tab

See NRLMMD-GEOIPS/geoips#529 for additional repositories included in this update.
See NRLMMD-GEOIPS/geoips#506 for dev updates included in this update.

# Testing Instructions
See NRLMMD-GEOIPS/geoips#529 for testing instructions.

# Output
See NRLMMD-GEOIPS/geoips#529 for test output.

# Post Merge Steps
Once this PR has been merged, v1.12.2
will be tagged/released on the geoips_clavrx main branch.