### PR TITLE
Store readable variables in dataset attributes so metadata_only returns them properly

### DIFF
--- a/docs/source/releases/latest/add-variable-metadata.yaml
+++ b/docs/source/releases/latest/add-variable-metadata.yaml
@@ -1,0 +1,12 @@
+bug fix:
+- title: 'Fix readable_variables attribute assignment in CLAVR-X reader'  
+  description: 'Sets the `readable_variables` attribute to the list of available variables in the CLAVR-X HDF4 file and assigns it before the metadata-only return, so that `metadata_only=True` calls still return the list of readable variables.'  
+  files:  
+    modified:  
+      - 'geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py'  
+  related-issue:  
+    number: null  
+    repo_url: ''  
+  date:  
+    start: '2026-02-10'  
+    finish: '2026-02-11'  

--- a/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
+++ b/geoips_clavrx/plugins/modules/readers/clavrx_hdf4.py
@@ -149,13 +149,15 @@ def read_cloudprops(fname, chans=None, metadata_only=False):
     return_dataset.attrs["sample_distance_km"] = data_metadata["RESOLUTION_KM"]  # 2km
     return_dataset.attrs["interpolation_radius_of_influence"] = 3000  # 3km
 
+    return_dataset.attrs["readable_variables"] = sorted(data.datasets().keys())
+
     # process of all variables
     if metadata_only:
         LOG.debug("metadata_only requested, returning without reading data")
         return return_dataset
 
     if chans is None:
-        var_names = sorted(data.datasets().keys())
+        var_names = return_dataset.attrs["readable_variables"]
     else:
         var_names = chans
 


### PR DESCRIPTION
**✨ Summary**

This PR fixes an issue in the CLAVR-X HDF4 reader where a `readable_variables` attribute wasn't being populated when `metadata_only=True` was specified. The fix adds a `readable_variables` assignment before the metadata-only return so that this attribute is available in metadata-only mode.

**Key changes:**
- Set `readable_variables` attribute to the list of available datasets in the CLAVR-X HDF4 file
- Assign `readable_variables` before the `metadata_only` return

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [x] **Full test**: Yes, full test *is passing*.
- [x] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

💖🌟🌎🌟💖